### PR TITLE
Optimize DTMF tone calculation

### DIFF
--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -1230,44 +1230,44 @@ void BK4819_EnableTXLink(void)
 void BK4819_PlayDTMF(char Code)
 {
 
-    struct DTMF_TonePair {
+    struct DTMF_RegPair {
         uint16_t tone1;
         uint16_t tone2;
     };
 
-    const struct DTMF_TonePair tones[] = {
-        {941, 1336},
-        {697, 1209},
-        {697, 1336},
-        {697, 1477},
-        {770, 1209},
-        {770, 1336},
-        {770, 1477},
-        {852, 1209},
-        {852, 1336},
-        {852, 1477},
-        {697, 1633},
-        {770, 1633},
-        {852, 1633},
-        {941, 1633},
-        {941, 1209},
-        {941, 1477},
+    // Pre-computed register values for the standard DTMF tone set
+    static const struct DTMF_RegPair tone_regs[] = {
+        {9715, 13793},
+        {7196, 12482},
+        {7196, 13793},
+        {7196, 15249},
+        {7950, 12482},
+        {7950, 13793},
+        {7950, 15249},
+        {8796, 12482},
+        {8796, 13793},
+        {8796, 15249},
+        {7196, 16860},
+        {7950, 16860},
+        {8796, 16860},
+        {9715, 16860},
+        {9715, 12482},
+        {9715, 15249},
     };
 
-
-    const struct DTMF_TonePair *pSelectedTone = NULL;
+    int index = -1;
     switch (Code)
     {
-        case '0'...'9': pSelectedTone = &tones[0  + Code - '0']; break;
-        case 'A'...'D': pSelectedTone = &tones[10 + Code - 'A']; break;
-        case '*': pSelectedTone = &tones[14]; break;
-        case '#': pSelectedTone = &tones[15]; break;
-        default: pSelectedTone = NULL;
+        case '0'...'9': index = 0  + Code - '0'; break;
+        case 'A'...'D': index = 10 + Code - 'A'; break;
+        case '*':       index = 14; break;
+        case '#':       index = 15; break;
+        default:        index = -1;
     }
 
-    if (pSelectedTone) {
-        BK4819_WriteRegister(BK4819_REG_71, (((uint32_t)pSelectedTone->tone1 * 103244) + 5000) / 10000);   // with rounding
-        BK4819_WriteRegister(BK4819_REG_72, (((uint32_t)pSelectedTone->tone2 * 103244) + 5000) / 10000);   // with rounding
+    if (index >= 0) {
+        BK4819_WriteRegister(BK4819_REG_71, tone_regs[index].tone1);
+        BK4819_WriteRegister(BK4819_REG_72, tone_regs[index].tone2);
     }
 }
 


### PR DESCRIPTION
## Summary
- precompute BK4819 DTMF register values
- use table lookup to program tones

## Testing
- `make -s` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e946fbf7c83239e346976c076c1e9