### PR TITLE
Optimize helper constants and inline check

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -42,13 +42,6 @@
 
 FUNCTION_Type_t gCurrentFunction;
 
-bool FUNCTION_IsRx()
-{
-    return gCurrentFunction == FUNCTION_MONITOR ||
-           gCurrentFunction == FUNCTION_INCOMING ||
-           gCurrentFunction == FUNCTION_RECEIVE;
-}
-
 void FUNCTION_Init(void)
 {
     g_CxCSS_TAIL_Found = false;

--- a/functions.h
+++ b/functions.h
@@ -37,6 +37,12 @@ extern FUNCTION_Type_t       gCurrentFunction;
 
 void FUNCTION_Init(void);
 void FUNCTION_Select(FUNCTION_Type_t Function);
-bool FUNCTION_IsRx();
+
+static inline bool FUNCTION_IsRx(void)
+{
+    return gCurrentFunction == FUNCTION_MONITOR ||
+           gCurrentFunction == FUNCTION_INCOMING ||
+           gCurrentFunction == FUNCTION_RECEIVE;
+}
 
 #endif

--- a/helper/battery.c
+++ b/helper/battery.c
@@ -45,12 +45,12 @@ typedef enum {
     BATTERY_LOW_CONFIRMED
 } BatteryLow_t;
 
-uint16_t          lowBatteryCountdown;
-const uint16_t    lowBatteryPeriod = 30;
+static uint16_t          lowBatteryCountdown;
+static const uint16_t    lowBatteryPeriod = 30;
 
 volatile uint16_t gPowerSave_10ms;
 
-const uint16_t Voltage2PercentageTable[][7][3] = {
+static const uint16_t Voltage2PercentageTable[][7][3] = {
     [BATTERY_TYPE_1600_MAH] = {
         {828, 100},
         {814, 97 },


### PR DESCRIPTION
## Summary
- inline `FUNCTION_IsRx` to reduce call overhead
- mark battery helper tables and counters as static const where possible

## Testing
- `make -n | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684e946fbf7c83239e346976c076c1e9